### PR TITLE
Support publish NuGet package on GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      packages: write
 
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
@@ -184,9 +186,13 @@ jobs:
           merge-multiple: true
           path: ./Excelize
 
+      - name: Install dotnet-validate
+        run: dotnet tool install --global dotnet-validate --version 0.0.1-preview.537
+
       - name: Pack and Publish Package
         run: |
           cd Excelize
           dotnet build -c Release && dotnet pack -c Release
+          dotnet-validate package local ./bin/ExcelizeCs*.nupkg
           dotnet nuget push ./bin/ExcelizeCs*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
           dotnet nuget push ./bin/ExcelizeCs*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --skip-duplicate

--- a/Excelize/Excelize.csproj
+++ b/Excelize/Excelize.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Authors>xuri</Authors>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <Copyright>Copyright © 2025 The Excelize Authors</Copyright>
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
+    <DebugType>embedded</DebugType>
     <Description>Excelize is a C# port of Go Excelize library that allow you to write to and read from XLAM / XLSM / XLSX / XLTM / XLTX files.</Description>
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnablePackageValidation>true</EnablePackageValidation>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIcon>logo.png</PackageIcon>
@@ -27,6 +27,9 @@
     <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Title>Excelize</Title>
     <Version>0.0.1</Version>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />


### PR DESCRIPTION
# PR Details

- Support publish NuGet package on GitHub
- Validate NuGet packages before publishing from GitHub Actions

## Description

- Support publish NuGet package on GitHub
- Validate NuGet packages before publishing from GitHub Actions

## Related Issue

N/A

## Motivation and Context

- Support publish NuGet package on GitHub
- Validate NuGet packages before publishing from GitHub Actions

## How Has This Been Tested

Run unit tests

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
